### PR TITLE
Make Ingress Host Optional

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -21,8 +21,12 @@ metadata:
   name: {{ .Values.ingress.serviceName }}
 spec:
   rules:
+{{- if .Values.ingress.endpoint }}
   - host: {{ .Values.ingress.endpoint }}.{{.Values.ingress.server}}
     http:
+{{ else }}
+  - http:
+{{- end }}
       paths:
       - path: /?(.*)
         backend:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-295

The release pipeline deploys mine-support without a host defined in the ingress.yaml. To allow the deployment to continue the setting the host URL must be optional.