### PR TITLE
Fix PR Regex in Pipeline

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -54,7 +54,7 @@ steps:
   # extracts merged PR number from git log if a PR merge to master
 - script: |
     gitLog=`git log -1 --pretty=%B`
-    mergedPrNo=`echo $gitLog | sed -n 's/Merge pull request #\(.*\) from .*/\1/p'`
+    mergedPrNo=`echo $gitLog | sed -n 's/.*(#\([0-9]\+\)).*/\1/p'`
     echo '##vso[task.setvariable variable=mergedPrNo]'$mergedPrNo
   condition: and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/heads/master'))
   displayName: extracts merged PR number if merge to branch
@@ -62,7 +62,6 @@ steps:
 - script: |
     mkdir test-output
     chmod 777 test-output
-    echo "source branch - '$(Build.SourceBranch)'"
   displayName: create test output directory
 - task: DockerCompose@0
   inputs:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-285

The pipeline identifies a PR is being merged from the text in the commit
message - a merge commit is always merged with a message containing the
PR number in brackets, i.e.
`my change (#11) furter details`

These changes ensure the correct value is extracted from the message on a
merge to master