### PR TITLE
 Only RegEx the First Line of Commit to Get PR

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -53,7 +53,7 @@ steps:
   displayName: set safe container tag as lower case container tag with illegal characters removed
   # extracts merged PR number from git log if a PR merge to master
 - script: |
-    gitLog=`git log -1 --pretty=%B`
+    gitLog=`git log --pretty=oneline --abbrev-commit -1`
     mergedPrNo=`echo $gitLog | sed -n 's/.*(#\([0-9]\+\)).*/\1/p'`
     echo '##vso[task.setvariable variable=mergedPrNo]'$mergedPrNo
   condition: and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/heads/master'))


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-285

The PR regular expression was searching the whole previous commit
message, not just the first line, matching the wrong PR number.