### PR TITLE
Change default ingress server

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -24,7 +24,7 @@ variables:
     imageName:  mine-support
     containerTag: $(Build.SourceBranchName)
     safeContainerTag: $(Build.SourceBranchName)
-    ingressServer: defradev.com
+    ingressServer: vividcloudsolutions.co.uk
     mergedPrNo:
 steps:
   # extracts PR number from refs/pull/{prNo}/ branch name and sets to containerTag if pull request

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -22,7 +22,7 @@ container:
 ingress:
   serviceName: mine-support
   endPoint: mine-support
-  server: defradev.com
+  server: vividcloudsolutions.co.uk
 replicas: 1
 minReadySeconds: 5
 cookiePassword: passwordpasswordpasswordpasswordpassword

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,7 +21,7 @@ container:
   restartPolicy: Always
 ingress:
   serviceName: mine-support
-  endPoint: mine-support
+  endpoint: mine-support
   server: vividcloudsolutions.co.uk
 replicas: 1
 minReadySeconds: 5

--- a/server/views/home.njk
+++ b/server/views/home.njk
@@ -16,7 +16,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Mine Support</h1>
+      <h1 class="govuk-heading-xl">Mine Support on a PR</h1>
 
       <p class="govuk-body">Use this service to:</p>
 


### PR DESCRIPTION
Change Default Ingress Server to VividCloudSolutions

https://eaflood.atlassian.net/browse/FPD-384

This PR is to test the CNAME wild card approach by using the vividcloudsolutions.co.uk DNS entry that has been configured with the appropriate settings.