### PR TITLE
Add missing build tasks

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -127,6 +127,7 @@ steps:
     releaseName: $(imageName)-$(containerTag)
     arguments: --set ingress.endpoint=$(imageName)-$(containerTag) --set ingress.server=$(ingressServer) --set auth=$(mineSupportAuth) --set image=$(azureContainerRegistryFull)/$(imageName):$(containerTag) --set container.redeployOnChange=$(Build.BuildId) --set container.imagePullPolicy=Always
     install: true
+    recreate: true
     waitForExecution: true
   displayName: Helm deploy
   # delete helm chart of closed PR

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -125,7 +125,7 @@ steps:
     chartType: filepath
     chartPath: helm
     releaseName: $(imageName)-$(containerTag)
-    arguments: --set ingress.endpoint=$(imageName)-$(containerTag) --set ingress.server=$(ingressServer) --set auth=$(mineSupportAuth) --set image=$(azureContainerRegistryFull)/$(imageName):$(containerTag) --set container.redeployOnChange=$(Build.BuildId) --set container.imagePullPolicy=Always
+    arguments: --set ingress.endpoint=$(imageName)-$(containerTag) --set ingress.server=$(ingressServer) --set auth=$(mineSupportAuth) --set image=$(azureContainerRegistryFull)/$(imageName):$(containerTag) --set container.redeployOnChange=$(Build.BuildId) --set container.imagePullPolicy=Always --atomic
     install: true
     recreate: true
     waitForExecution: true

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -180,3 +180,25 @@ steps:
 - script: |
     echo "Build available for review at http://$(imageName)-$(containerTag).$(ingressServer)"
   displayName: display URL of deployed build
+# install helm on build agent
+- task: HelmInstaller@0
+  displayName: 'Install Helm 2.9.1'
+  inputs:
+    helmVersion: 2.9.1
+  # package helm chart for release
+- task: HelmDeploy@0
+  displayName: 'helm package'
+  inputs:
+    command: package
+    chartPath: ./helm
+    save: false
+  # copy yaml values for release  
+- task: CopyFiles@2
+  displayName: 'Copy values files'
+  inputs:
+    SourceFolder: helm
+    Contents: '*-values.yaml'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)'
+  # publish artifact for release
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifacts: drop'

--- a/helm/production-values.yaml
+++ b/helm/production-values.yaml
@@ -1,4 +1,4 @@
 environment: production
-image: minesupport.azurecr.io/mine-support
+image: jwminesupport.azurecr.io/mine-support
 container:
-  imagePullPolicy: Always
+    imagePullPolicy: Always

--- a/helm/production2-values.yaml
+++ b/helm/production2-values.yaml
@@ -1,4 +1,0 @@
-environment: production
-image: jwminesupport.azurecr.io/mine-support
-container:
-    imagePullPolicy: Always


### PR DESCRIPTION
Currently the build pipeline has no tasks to package the helm charts and values for release to AKS.

These changes resolve that.