### PR TITLE
Allow Optional Registry Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,11 @@ The [azure-pipelines.yaml](azure-pipelines.yaml) performs the following tasks:
 
 Builds will be deployed into a namespace with the format `mine-support-{identifier}` where `{identifier}` is either the release version, the PR number, or the branch name.
 
-The builds will be available at the URL `http://mine-support-{identifier}.{ingress-server}`, where `{ingress-server}` is the ingress server defined the [`values.yaml`](./helm/values.yaml),  which is `defradev.com` by default.
+The builds will be available at the URL `http://mine-support-{identifier}.{ingress-server}`, where `{ingress-server}` is the ingress server defined the [`values.yaml`](./helm/values.yaml),  which is `vividcloudsolutions.co.uk` by default.
 
 The temporary deployment requires a CNAME subdomain wildcard pointing to the public IP address of the ingress controller of the Kubernetes cluster. This can be simulated by updating your local `hosts` file with an entry for the build address set to the ingress controller's public IP address. On windows this would mean adding a line to `C:\Windows\System32\drivers\etc\hosts`, i.e. for PR 8 against the default ingress server this would be
 
-xx.xx.xx.xx mine-support-pr8.defradev.com
+xx.xx.xx.xx mine-support-pr8.vividcloudsolutions.co.uk
 
 where `xx.xx.xx.xx` is the public IP Address of the Ingress Controller.
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -24,7 +24,7 @@ variables:
     imageName:  mine-support
     containerTag: $(Build.SourceBranchName)
     safeContainerTag: $(Build.SourceBranchName)
-    ingressServer: defradev.com
+    ingressServer: vividcloudsolutions.co.uk
     mergedPrNo:
 steps:
   # extracts PR number from refs/pull/{prNo}/ branch name and sets to containerTag if pull request

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
         redeployOnChange: "{{ .Values.container.redeployOnChange }}"
     spec:
       restartPolicy: {{ .Values.container.restartPolicy }}
+      {{- if .Values.imagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecret }}
+      {{- end }}
       containers:
       - name: {{ .Values.name }}
         image: {{ .Values.image }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,6 +2,7 @@ environment: development
 image: mine-support
 name: mine-support
 auth:
+imagePullSecret:
 service:
   port: 80
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,7 +2,7 @@ environment: development
 image: mine-support
 name: mine-support
 auth:
-imagePullSecret:
+imagePullSecret: regcred
 service:
   port: 80
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,7 +2,7 @@ environment: development
 image: mine-support
 name: mine-support
 auth:
-imagePullSecret: regcred
+imagePullSecret: 
 service:
   port: 80
 
@@ -24,7 +24,7 @@ container:
 ingress:
   serviceName: mine-support
   endPoint: mine-support
-  server: defradev.com
+  server: vividcloudsolutions.co.uk
 replicas: 1
 minReadySeconds: 5
 cookiePassword: passwordpasswordpasswordpasswordpassword


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-440

To deploy from a private registry into a Kubernetes cluster registry
credentials must be supplied. this PR adds configuration to the
deployment chart to allow authentication.